### PR TITLE
update maplibre-compose docs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ It is based off `maplibre-compose`
 
 > MapLibre Compose is a [Compose Multiplatform](https://www.jetbrains.com/compose-multiplatform/) wrapper around the [MapLibre](MapLibre) SDKs for rendering interactive maps. You can use it to add maps to your Compose UIs on Android, iOS, Desktop, and Web.
 
-[https://sargunv.github.io/maplibre-compose/](https://sargunv.github.io/maplibre-compose/) 
+[https://maplibre.org/maplibre-compose/](https://maplibre.org/maplibre-compose/) 


### PR DESCRIPTION
related: https://github.com/maplibre/maplibre/issues/441

the old docs url is now dead, because GH does not redirect Pages urls after a repo move.